### PR TITLE
Ensure log scripts create log directory

### DIFF
--- a/cleanup_caches.sh
+++ b/cleanup_caches.sh
@@ -5,6 +5,8 @@
 # Created: $(date)
 
 LOG_FILE="$HOME/Library/Logs/cache_cleanup.log"
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
 TOTAL_FREED=0
 
 # Function to log messages

--- a/disable_bloat_services.sh
+++ b/disable_bloat_services.sh
@@ -7,6 +7,8 @@
 # Created: $(date)
 
 LOG_FILE="$HOME/Library/Logs/disable_bloat_services.log"
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
 SERVICES_DISABLED=0
 SERVICES_FAILED=0
 PROCESSES_KILLED=0

--- a/restore_macos_services.sh
+++ b/restore_macos_services.sh
@@ -14,6 +14,8 @@
 # Repository: https://github.com/manooll/Lean_Mac
 
 LOG_FILE="$HOME/Library/Logs/restore_macos_services.log"
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
 SCRIPT_VERSION="1.0"
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 


### PR DESCRIPTION
## Summary
- create log directory before writing logs in disable, cleanup, and restore scripts

## Testing
- `bash -n disable_bloat_services.sh`
- `bash -n cleanup_caches.sh`
- `bash -n restore_macos_services.sh`
- `shellcheck disable_bloat_services.sh cleanup_caches.sh restore_macos_services.sh` *(warnings only)*
- `rm -rf ~/Library && bash disable_bloat_services.sh`
- `rm -rf ~/Library && bash cleanup_caches.sh`
- `rm -rf ~/Library && bash restore_macos_services.sh`

------
https://chatgpt.com/codex/tasks/task_b_689646daadbc83338b7a4b47c7259110