### PR TITLE
Fix success_rate assignment in restore script

### DIFF
--- a/restore_macos_services.sh
+++ b/restore_macos_services.sh
@@ -336,7 +336,7 @@ log_message "🔍 Key services verified: $enabled_count/$(echo ${#check_services
 
 # Calculate success rate
 if [ $((SERVICES_ENABLED + SERVICES_FAILED)) -gt 0 ]; then
-    local success_rate=$((SERVICES_ENABLED * 100 / (SERVICES_ENABLED + SERVICES_FAILED)))
+    success_rate=$((SERVICES_ENABLED * 100 / (SERVICES_ENABLED + SERVICES_FAILED)))
     log_message "📈 Service restoration success rate: ${success_rate}%"
 fi
 


### PR DESCRIPTION
## Summary
- Remove `local` before success_rate to avoid non-function usage error

## Testing
- `bash -n restore_macos_services.sh`
- `bash restore_macos_services.sh` *(fails: sw_vers: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689646c60c60833391b45b7bb5becb8a