### PR TITLE
Harden cache cleanup script against empty paths

### DIFF
--- a/cleanup_caches.sh
+++ b/cleanup_caches.sh
@@ -29,17 +29,19 @@ clean_cache() {
     local keep_recent="${3:-false}"
     
     if [ -d "$cache_dir" ]; then
-        local size_before=$(get_dir_size "$cache_dir")
-        
+        local size_before
+        size_before=$(get_dir_size "$cache_dir")
+
         if [ "$keep_recent" = "true" ]; then
             # Keep files newer than 7 days
-            find "$cache_dir" -type f -mtime +7 -delete 2>/dev/null
+            find "${cache_dir:?}" -type f -mtime +7 -delete 2>/dev/null
         else
-            # Remove all cache files
-            rm -rf "$cache_dir"/* 2>/dev/null
+            # Remove all cache files safely
+            rm -rf "${cache_dir:?}/"* 2>/dev/null
         fi
-        
-        local size_after=$(get_dir_size "$cache_dir")
+
+        local size_after
+        size_after=$(get_dir_size "$cache_dir")
         local freed=$((size_before - size_after))
         TOTAL_FREED=$((TOTAL_FREED + freed))
         


### PR DESCRIPTION
## Summary
- avoid dangerous `rm -rf` on empty cache directories by asserting non-empty paths
- split variable declarations from assignments in `clean_cache` for clarity

## Testing
- `shellcheck cleanup_caches.sh`
- `bash -n cleanup_caches.sh`


------
https://chatgpt.com/codex/tasks/task_b_6896454b253483339e6f25a6592af222