### PR TITLE
docs: fix quick-start directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Found a new bloat service? Performance issue? We want to hear about it.
 **Quick start:**
 ```bash
 git clone https://github.com/manooll/Lean_Mac.git
-cd macos-bloat-disabler
+cd Lean_Mac
 sudo ./install.sh  # Test on a VM first!
 ```
 


### PR DESCRIPTION
## Summary
- fix quick-start instructions to enter the correct repository directory

## Testing
- `git clone https://github.com/manooll/Lean_Mac.git`
- `cd Lean_Mac`
- `sudo ./install.sh` *(fails: This script is designed for macOS only)*

------
https://chatgpt.com/codex/tasks/task_b_68964b6649d48333aee745f07c9d2d15