### PR TITLE
Use dynamic home paths in agent plist

### DIFF
--- a/com.user.disablebloatservices.agent.plist
+++ b/com.user.disablebloatservices.agent.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.user.disablebloatservices</string>
+    <string>com.user.disablebloatservices.agent</string>
     
     <key>ProgramArguments</key>
     <array>
@@ -14,10 +14,10 @@
     <true/>
     
     <key>StandardOutPath</key>
-    <string>/Users/pramana/Library/Logs/disable_bloat_services.log</string>
+    <string>$HOME/Library/Logs/disable_bloat_services.log</string>
     
     <key>StandardErrorPath</key>
-    <string>/Users/pramana/Library/Logs/disable_bloat_services.log</string>
+    <string>$HOME/Library/Logs/disable_bloat_services.log</string>
     
     <key>StartInterval</key>
     <integer>300</integer>


### PR DESCRIPTION
## Summary
- rename LaunchAgent label to `com.user.disablebloatservices.agent`
- replace hard-coded log paths with `$HOME/Library/Logs/disable_bloat_services.log`

## Testing
- `plutil -lint com.user.disablebloatservices.agent.plist`


------
https://chatgpt.com/codex/tasks/task_b_68964e29b07c8333a1bf8f2331065d99