### PR TITLE
Enable strict mode in shell scripts

### DIFF
--- a/cleanup_caches.sh
+++ b/cleanup_caches.sh
@@ -4,6 +4,8 @@
 # Cleans up heavy cache directories to free disk space
 # Created: $(date)
 
+set -euo pipefail
+
 LOG_FILE="$HOME/Library/Logs/cache_cleanup.log"
 # Ensure log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -41,7 +43,6 @@ clean_cache() {
 
             # Remove all cache files safely
             rm -rf "${cache_dir:?}/"* 2>/dev/null
-        main
         fi
 
         local size_after
@@ -117,14 +118,14 @@ fi
 log_message "--- Running System Maintenance ---"
 if command -v brew >/dev/null 2>&1; then
     log_message "🍺 RUNNING: Homebrew cleanup"
-    brew cleanup --prune=all >/dev/null 2>&1
+    brew cleanup --prune=all >/dev/null 2>&1 || true
     log_message "🍺 COMPLETED: Homebrew cleanup"
 fi
 
 # Docker cleanup if installed
 if command -v docker >/dev/null 2>&1; then
     log_message "🐳 RUNNING: Docker cleanup"
-    docker system prune -f >/dev/null 2>&1
+    docker system prune -f >/dev/null 2>&1 || true
     log_message "🐳 COMPLETED: Docker cleanup"
 fi
 

--- a/disable_bloat_services.sh
+++ b/disable_bloat_services.sh
@@ -6,6 +6,8 @@
 # UPDATED: Added system update protection and safer process handling
 # Created: $(date)
 
+set -euo pipefail
+
 LOG_FILE="$HOME/Library/Logs/disable_bloat_services.log"
 # Ensure log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -134,7 +136,7 @@ disable_service() {
     local disabled=false
     
     # Get all logged-in users
-    for user_id in $(ps -axo uid,comm | grep loginwindow | awk '{print $1}' | sort -u); do
+    for user_id in $(ps -axo uid,comm | grep loginwindow | awk '{print $1}' | sort -u || true); do
         if [[ "$user_id" =~ ^[0-9]+$ ]] && [ "$user_id" -ge 500 ]; then
             # Try to disable for this user
             if launchctl print "gui/$user_id" 2>/dev/null | grep -q "$service_name" 2>/dev/null; then
@@ -201,7 +203,7 @@ check_system_updates() {
     fi
     
     # Check for high mobileassetd CPU usage (indicates active downloading)
-    local mobileasset_cpu=$(ps -eo pid,pcpu,comm | grep mobileassetd | awk '{if($2 > 5.0) print $1}' | head -1)
+    local mobileasset_cpu=$(ps -eo pid,pcpu,comm | grep mobileassetd | awk '{if($2 > 5.0) print $1}' | head -1 || true)
     if [ -n "$mobileasset_cpu" ]; then
         log_message "⚠️  HIGH MOBILEASSETD ACTIVITY DETECTED - Likely downloading updates"
         log_message "🛑 ABORTING: Will not run debloat service during asset downloads"

--- a/install.sh
+++ b/install.sh
@@ -2,18 +2,18 @@
 
 # macOS Tahoe 26.0 Bloat Service Disabler - Installation Script
 # Version: 2.1
-# 
+#
 # This script installs the macOS Bloat Service Disabler system including:
 # - Main bloat service disabler script
 # - Cache cleanup utility (separate)
 # - LaunchDaemon for system-wide operation
 # - LaunchAgent for user-specific operation
-# 
+#
 # Author: Jay L. [Manull]
 # License: MIT
 # Repository: https://github.com/manooll/Lean_Mac.git
 
-set -e  # Exit on any error
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -57,7 +57,7 @@ check_root() {
 
 # Function to get the actual user (not root when using sudo)
 get_actual_user() {
-    if [ -n "$SUDO_USER" ]; then
+    if [ -n "${SUDO_USER:-}" ]; then
         echo "$SUDO_USER"
     else
         echo "$(whoami)"

--- a/restore_macos_services.sh
+++ b/restore_macos_services.sh
@@ -3,15 +3,17 @@
 # macOS Tahoe 26.0 Service Restore Script
 # Version: 1.0 - Companion to Bloat Service Disabler
 # Purpose: Restore all services and functionality disabled by the bloat disabler
-# 
+#
 # This script will:
 # - Re-enable all disabled services
 # - Restore Spotlight indexing
 # - Provide system health verification
-# 
+#
 # Author: Jay L. [Manull]
 # License: MIT
 # Repository: https://github.com/manooll/Lean_Mac
+
+set -euo pipefail
 
 LOG_FILE="$HOME/Library/Logs/restore_macos_services.log"
 # Ensure log directory exists
@@ -127,19 +129,19 @@ capture_performance_metrics() {
     log_message "📊 PERFORMANCE METRICS ($label):"
     
     # CPU usage snapshot
-    local cpu_usage=$(top -l 1 -s 0 | grep "CPU usage" | head -1)
+    local cpu_usage=$(top -l 1 -s 0 | grep "CPU usage" | head -1 || true)
     log_message "CPU: $cpu_usage"
     
     # Memory usage
-    local memory_info=$(vm_stat | head -5 | tr '\n' ' ')
+    local memory_info=$(vm_stat | head -5 | tr '\n' ' ' || true)
     log_message "Memory: $memory_info"
     
     # Process count
-    local proc_count=$(ps aux | wc -l)
+    local proc_count=$(ps aux | wc -l || true)
     log_message "Process count: $proc_count"
     
     # Disk space
-    local disk_usage=$(df -h / | tail -1 | awk '{print "Used: "$3" Available: "$4" ("$5" full)"}')
+    local disk_usage=$(df -h / | tail -1 | awk '{print "Used: "$3" Available: "$4" ("$5" full)"}' || true)
     log_message "Disk: $disk_usage"
 }
 
@@ -149,7 +151,7 @@ enable_service() {
     local enabled=false
     
     # Get all logged-in users
-    for user_id in $(ps -axo uid,comm | grep loginwindow | awk '{print $1}' | sort -u); do
+    for user_id in $(ps -axo uid,comm | grep loginwindow | awk '{print $1}' | sort -u || true); do
         if [[ "$user_id" =~ ^[0-9]+$ ]] && [ "$user_id" -ge 500 ]; then
             # Try to enable for this user
             if launchctl enable "gui/$user_id/$service_name" 2>/dev/null; then
@@ -289,7 +291,7 @@ mdutil -sa 2>/dev/null | awk -F ':' '{print $1}' | while IFS= read -r vol; do
     else
         log_message "❌ Failed to enable indexing on $vol"
     fi
-done
+done || true
 
 # --- 3. Enable User-Level Services ---
 log_message "🟢 ENABLING USER-LEVEL SERVICES..."


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` to project shell scripts
- guard against unset variables like `SUDO_USER`
- harden pipelines in scripts for pipefail safety

## Testing
- `tests/shellcheck.sh` *(fails: SC2317, SC2155 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68964e30684c83338603184abe79653e